### PR TITLE
Add uniform bucket-level access option

### DIFF
--- a/docs/content/commands/rclone.md
+++ b/docs/content/commands/rclone.md
@@ -354,7 +354,8 @@ rclone [flags]
       --gcs-anonymous                                       Access public buckets and objects without credentials
       --gcs-auth-url string                                 Auth server URL
       --gcs-bucket-acl string                               Access Control List for new buckets
-      --gcs-bucket-policy-only                              Access checks should use bucket-level IAM policies
+      --gcs-bucket-policy-only                              Access checks should use uniform bucket-level access (deprecated)
+      --gcs-uniform-bucket-level-access                     Access checks should use uniform bucket-level access
       --gcs-client-credentials                              Use client credentials OAuth flow
       --gcs-client-id string                                OAuth Client Id
       --gcs-client-secret string                            OAuth Client Secret

--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -616,7 +616,8 @@ Backend-only flags (these can be set in the config file also).
       --gcs-anonymous                                       Access public buckets and objects without credentials
       --gcs-auth-url string                                 Auth server URL
       --gcs-bucket-acl string                               Access Control List for new buckets
-      --gcs-bucket-policy-only                              Access checks should use bucket-level IAM policies
+      --gcs-bucket-policy-only                              Access checks should use uniform bucket-level access (deprecated)
+      --gcs-uniform-bucket-level-access                     Access checks should use uniform bucket-level access
       --gcs-client-credentials                              Use client credentials OAuth flow
       --gcs-client-id string                                OAuth Client Id
       --gcs-client-secret string                            OAuth Client Secret

--- a/docs/content/googlecloudstorage.md
+++ b/docs/content/googlecloudstorage.md
@@ -483,7 +483,9 @@ Properties:
 
 #### --gcs-bucket-policy-only
 
-Access checks should use bucket-level IAM policies.
+Deprecated: use `--gcs-uniform-bucket-level-access`.
+
+Access checks should use uniform bucket-level access.
 
 If you want to upload objects to a bucket with Bucket Policy Only set
 then you will need to set this.
@@ -492,15 +494,38 @@ When it is set, rclone:
 
 - ignores ACLs set on buckets
 - ignores ACLs set on objects
-- creates buckets with Bucket Policy Only set
+- creates buckets with Uniform Bucket-Level Access set
 
-Docs: https://cloud.google.com/storage/docs/bucket-policy-only
+Docs: https://cloud.google.com/storage/docs/uniform-bucket-level-access
 
 
 Properties:
 
 - Config:      bucket_policy_only
 - Env Var:     RCLONE_GCS_BUCKET_POLICY_ONLY
+- Type:        bool
+- Default:     false
+
+#### --gcs-uniform-bucket-level-access
+
+Access checks should use uniform bucket-level access.
+
+If you want to upload objects to a bucket with Uniform Bucket-Level Access set
+then you will need to set this.
+
+When it is set, rclone:
+
+- ignores ACLs set on buckets
+- ignores ACLs set on objects
+- creates buckets with Uniform Bucket-Level Access set
+
+Docs: https://cloud.google.com/storage/docs/uniform-bucket-level-access
+
+
+Properties:
+
+- Config:      uniform_bucket_level_access
+- Env Var:     RCLONE_GCS_UNIFORM_BUCKET_LEVEL_ACCESS
 - Type:        bool
 - Default:     false
 


### PR DESCRIPTION
## Summary
- support Uniform Bucket-Level Access in GCS backend
- document new `--gcs-uniform-bucket-level-access` option
- mark old `--gcs-bucket-policy-only` option as deprecated

## Testing
- `make quicktest` *(fails: fetching dependencies from storage.googleapis.com forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686677d90a0883288a6df1519f0f5f0f